### PR TITLE
Add C++ style comments

### DIFF
--- a/comment.7
+++ b/comment.7
@@ -2,14 +2,15 @@
 .SH NAME
 comment \- Toggles commenting of lines of code.
 .SH CONFIGURATION
-None
+.SS cpp-style-comments [ yes / no ]
+If this variable is true, single line C++ style comments will be used.
 .SH COMMANDS
 .SS comment-toggle
 Toggles the current line. If there is a selection, toggles every line in the selection.
 .SH BUFFERS
 None
 .SH NOTES
-Implemented filetypes are: C, C++, Shell, bJou, Python, yedrc, LaTeX
+Implemented filetypes are: C, C++, Golang, Zig, Shell, bJou, Python, yedrc, LaTeX
 .SH VERSION
 0.0.1
 .SH KEYWORDS

--- a/comment.c
+++ b/comment.c
@@ -15,13 +15,16 @@ void comment_toggle_line_latex(yed_frame *frame, yed_line *line, int row);
 void comment_line_latex(yed_frame *frame, int row);
 void uncomment_line_latex(yed_frame *frame, int row);
 
-void comment_toggle_line_zig(yed_frame *frame, yed_line *line, int row);
-void comment_line_zig(yed_frame *frame, int row);
-void uncomment_line_zig(yed_frame *frame, int row);
+void comment_toggle_line_cpp(yed_frame *frame, yed_line *line, int row);
+void comment_line_cpp(yed_frame *frame, int row);
+void uncomment_line_cpp(yed_frame *frame, int row);
 
 int yed_plugin_boot(yed_plugin *self) {
     YED_PLUG_VERSION_CHECK();
 
+    if (yed_get_var("cpp-style-comments") == NULL) {
+        yed_set_var("cpp-style-comments", "no");
+    }
     yed_plugin_set_command(self, "comment-toggle", comment_toggle);
     return 0;
 }
@@ -89,7 +92,11 @@ int comment_toggle_line(yed_frame *frame, yed_line *line, int row) {
     if (       frame->buffer->ft == yed_get_ft("C")       ||
                frame->buffer->ft == yed_get_ft("C++")     ||
                frame->buffer->ft == yed_get_ft("Golang")) {
-        comment_toggle_line_c(frame, line, row);
+        if (yed_var_is_truthy("cpp-style-comments")){
+            comment_toggle_line_cpp(frame, line, row);
+        } else {
+            comment_toggle_line_c(frame, line, row);
+        }
 
     } else if (frame->buffer->ft == yed_get_ft("Shell")  ||
                frame->buffer->ft == yed_get_ft("bJou")   ||
@@ -101,7 +108,7 @@ int comment_toggle_line(yed_frame *frame, yed_line *line, int row) {
         comment_toggle_line_latex(frame, line, row);
 
     } else if (frame->buffer->ft == yed_get_ft("Zig"))   {
-        comment_toggle_line_zig(frame, line, row);
+        comment_toggle_line_cpp(frame, line, row);
 
     } else {
         return 0;
@@ -219,8 +226,8 @@ void uncomment_line_latex(yed_frame *frame, int row) {
     yed_delete_from_line(frame->buffer, row, 1);
 }
 
-/* Zig */
-void comment_toggle_line_zig(yed_frame *frame, yed_line *line, int row) {
+/* CPP style comments*/
+void comment_toggle_line_cpp(yed_frame *frame, yed_line *line, int row) {
     int        line_len;
     yed_glyph *g;
 
@@ -234,22 +241,22 @@ void comment_toggle_line_zig(yed_frame *frame, yed_line *line, int row) {
             if (g->c == '/') {
                 g = yed_line_col_to_glyph(line, 3);
                 if (g->c == ' ') {
-                    uncomment_line_zig(frame, row);
+                    uncomment_line_cpp(frame, row);
                     return;
                 }
             }
         }
     }
-    comment_line_zig(frame, row);
+    comment_line_cpp(frame, row);
 }
 
-void comment_line_zig(yed_frame *frame, int row) {
+void comment_line_cpp(yed_frame *frame, int row) {
     yed_insert_into_line(frame->buffer, row, 1, G(' '));
     yed_insert_into_line(frame->buffer, row, 1, G('/'));
     yed_insert_into_line(frame->buffer, row, 1, G('/'));
 }
 
-void uncomment_line_zig(yed_frame *frame, int row) {
+void uncomment_line_cpp(yed_frame *frame, int row) {
     yed_delete_from_line(frame->buffer, row, 1);
     yed_delete_from_line(frame->buffer, row, 1);
     yed_delete_from_line(frame->buffer, row, 1);


### PR DESCRIPTION
Remove: Zig naming convention for the comment style
Add: CPP tot he naming convention for the comment style and support for using it in C/C++/Golang

This way we can reuse the function and add the option to configure it, pretty convenient to have the option to use C++ style comments specially for some formatter shenanigans.